### PR TITLE
Adds custom clean and view logic for enforcing only one cover story

### DIFF
--- a/wavepool/admin.py
+++ b/wavepool/admin.py
@@ -7,6 +7,21 @@ class NewsPostForm(forms.ModelForm):
     model = NewsPost
     fields = '__all__'
 
+    def clean(self, *args, **kwargs):
+        """ cleans form data
+        """
+        # user selected "is cover story checkbox":
+        if self.data.get('is_cover_story') == 'on':
+            all_newsposts = NewsPost.objects.all()
+            # for each newspost, if it is the current cover story and NOT this newspost anyways,
+            # unset it as cover story and save
+            for n in all_newsposts:
+                if n.is_cover_story == True:
+                    if n != self.instance:
+                        n.is_cover_story = False
+            n.save()
+        return super(NewsPostForm, self).clean(*args, **kwargs)
+
 
 class NewsPostAdmin(admin.ModelAdmin):
     form = NewsPostForm

--- a/wavepool/models.py
+++ b/wavepool/models.py
@@ -32,7 +32,17 @@ class NewsPost(models.Model):
 
     @property
     def source_divesite_name(self):
-        return 'Industry Dive'
+        """ Return the real divesite source name for the newspost's source
+        """
+        source_dive = 'Industry Dive'
+        for dive_source in DIVESITE_SOURCE_NAMES:
+            url_parts = self.source.split('/')
+            dive_domain = url_parts[2]
+            domain_parts = dive_domain.split('.')
+            dive_domain = domain_parts[1]
+            if dive_domain == dive_source:
+                return DIVESITE_SOURCE_NAMES[dive_domain]
+        return source_dive
 
     def tags(self):
         return [

--- a/wavepool/views.py
+++ b/wavepool/views.py
@@ -14,9 +14,20 @@ def front_page(request):
             archive: the rest of the newsposts, sorted by most recent
     """
     template = loader.get_template('wavepool/frontpage.html')
-    cover_story = NewsPost.objects.all().order_by('?').first()
-    top_stories = NewsPost.objects.all().order_by('?')[:3]
-    other_stories = NewsPost.objects.all().order_by('?')
+    cover_story = None
+    top_stories = []
+    other_stories = []
+    newsposts = NewsPost.objects.all().order_by('publish_date')
+
+    i = 1
+    for n in newsposts:
+        if n.is_cover_story == True:
+            cover_story = n
+        if i < 3:
+            top_stories.append(n)
+            i = i + 1
+        else:
+            other_stories.append(n)
 
     context = {
         'cover_story': cover_story,


### PR DESCRIPTION
## Business requirements
* CMS user can set only 1 cover story at a time
* Site visitor sees the cover story in the cover story section of the front page
* Site visitor sees the three most recent stories excluding the cover story in the top news of the front page, ordered by most recent
* Site visitor sees all remaining stories in the archive section of the front page, ordered by most recent

## Technical context
* Adds a custom clean to the newspost form to unset previous cover story and set new cover story
* Adds logic to the front page view that selects the correct story as cover story and organizes the remaining stories by top section or archive section

## Manual testing
* In the CMS, set a news post as the cover story on the news post change form
* Open the change form a different news post and set it as cover story, and verify that the previous one is no longer set as the cover story
* On the site front page and verify that they current cover story is displayed as the cover story
* On the site front page, verify the top stories is the next 3 most recent stories and the archive is all remaining stories
* Run the CmsPage.test_only_one_cover_story test and it passes