### PR TITLE
fixes for site front page

### DIFF
--- a/wavepool/templates/wavepool/frontpage.html
+++ b/wavepool/templates/wavepool/frontpage.html
@@ -4,14 +4,14 @@
 {% block page_content %}
 	<div class="row">
 		<div class="col-md-4">
-			<div id="coverstory" class="row" data-newspost-id="{{cover_story.pk}}">
+			<div id="coverstory" class="row" data-story-id="{{cover_story.pk}}">
 				<h2>Cover story</h2>
 				<div class="title">
 					<span class="pubdate">{{cover_story.publish_date}}</span>
 					<a href="{{ cover_story.url }}">{{ cover_story.title }}</a>
 				</div>
 				<div><img src="media/image/placeholder-img.jpg"  width="300" height="175" /></div>
-				<div class="newspost-teaser" data-newspost-id="{{cover_story.pk}}">
+				<div class="newspost-teaser" data-story-id="{{cover_story.pk}}">
 					{{ cover_story.teaser|safe }} ...
 				</div>
 			</div>
@@ -20,10 +20,10 @@
 			<div class="row"><h2>Top Stories</h2></div>
 			<div class="row">
 				{% for newspost in top_stories %}
-					<div class="topstory" data-newspost-id="{{newspost.pk}}" data-top-story-placement="{{forloop.counter}}">
+					<div class="topstory" data-story-id="{{newspost.pk}}" data-top-story-placement="{{forloop.counter}}">
 						<span class="pubdate">{{newspost.publish_date}}</span>
 						<div class="frontpage-archive_link"><a href="{{ newspost.url }}">{{ newspost.title }}</a></div>
-						<div class="newspost-teaser" data-story_id="{{newspost.pk}}">
+						<div class="newspost-teaser" data-story-id="{{newspost.pk}}">
 							{{ newspost.teaser|safe  }} ...
 						</div>
 					<hr />
@@ -37,7 +37,7 @@
 		<div class="row">
 			<div id="archive-stories">
 				{% for newspost in archive %}
-					<div class="archived-story" data-archive-newspost-id="{{newspost.pk}}">
+					<div class="archived-story" data-archive-story-id="{{newspost.pk}}">
 						<span class="pubdate">{{newspost.publish_date}}</span>
 						<div class="frontpage-archive_link"><a href="{{ newspost.url }}">{{ newspost.title }}</a></div>
 						<div class="newspost-teaser" data-story_id="{{newspost.pk}}">

--- a/wavepool/tests.py
+++ b/wavepool/tests.py
@@ -115,7 +115,7 @@ class SiteFrontPage(TestBase):
     def test_cover_story_placement(self):
         """ Verify that the story designated as the cover story appears in the cover story box on the front page
         """
-        cover_story = NewsPost.objects.all().order_by('?').first()
+        cover_story = NewsPost.objects.all().order_by('publish_date').first()
         cover_story.is_cover_story = True
         cover_story.save()
 

--- a/wavepool/views.py
+++ b/wavepool/views.py
@@ -14,9 +14,17 @@ def front_page(request):
             archive: the rest of the newsposts, sorted by most recent
     """
     template = loader.get_template('wavepool/frontpage.html')
-    cover_story = NewsPost.objects.all().order_by('?').first()
-    top_stories = NewsPost.objects.all().order_by('?')[:3]
-    other_stories = NewsPost.objects.all().order_by('?')
+
+    cover_story, top_stories, other_stories = None, [], []
+    count = 0
+    for story in NewsPost.objects.all().order_by('publish_date'):
+        if story.is_cover_story:
+            cover_story = story
+        elif count < 3:
+            top_stories.append(story)
+            count += 1
+        else:
+            other_stories.append(story)
 
     context = {
         'cover_story': cover_story,


### PR DESCRIPTION
There are several bugs on the front page of the Wavepool site. This pull request is to fix these bugs by editing the front_pag.html template file and the front_page view in views.py. 

The following bugs has been fixed:
The newspost designated as the cover story should appear in the cover story box
The 3 most recent stories, excluding the cover story, should be displayed under "top stories", ordered by most recent first
All news posts that do not appear as the cover story or as top stories should be listed in the archive, ordered by most recent first
Newspost teasers should be properly rendered as HTML