### PR TITLE
Lachlan's PR for Industry Dive Candidacy

### DIFF
--- a/wavepool/models.py
+++ b/wavepool/models.py
@@ -2,6 +2,8 @@ from django.db import models
 from django.urls import reverse
 
 import datetime
+import re
+from bs4 import BeautifulSoup
 
 DIVESITE_SOURCE_NAMES = {
     'retaildive': 'Retail Dive',
@@ -14,6 +16,8 @@ DIVESITE_SOURCE_NAMES = {
     'hrdive': 'HR Dive',
 }
 
+divesite_source_pattern = re.compile(r'www\.(.*)\.com')
+
 
 class NewsPost(models.Model):
     title = models.CharField(max_length=300)
@@ -21,6 +25,17 @@ class NewsPost(models.Model):
     source = models.URLField()
     is_cover_story = models.BooleanField(default=False)
     publish_date = models.DateField(default=datetime.date.today())
+
+    @property
+    def clean_body(self):
+        """We can't trust what's in the database to give us valid html. Normally
+        I would fix this at the point of user input. For example give a validation
+        error or just try to correct the error there.
+
+        As it is I'm not changing the database, this is a quick fix to at least
+        make it look a little bit cleaner for the browser (and testcases).
+        """
+        return BeautifulSoup(self.body, 'html.parser').prettify()
 
     @property
     def url(self):
@@ -32,6 +47,13 @@ class NewsPost(models.Model):
 
     @property
     def source_divesite_name(self):
+        """Try and pull the divesite name from the source url. If you find one,
+        look it up in DIVESITE_SOURCE_NAMES. If not, default to Industry Dive"""
+        match = divesite_source_pattern.findall(self.source)
+
+        if match:
+            return DIVESITE_SOURCE_NAMES[match[0]]
+
         return 'Industry Dive'
 
     def tags(self):

--- a/wavepool/templates/wavepool/base.html
+++ b/wavepool/templates/wavepool/base.html
@@ -3,7 +3,9 @@
 	<head>
   		<link href="{% static 'bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
   		<link href="{% static 'app.css' %}" rel="stylesheet">
-  		<title>Wavepool | Industry Dive</title>
+  		{%  block title %}
+        <title>Wavepool | Industry Dive</title>
+        {%  endblock %}
   		<link rel="shortcut icon" type="/image/png" href="{% static 'favicon.ico' %}"/>
   </head>
 	<body>

--- a/wavepool/templates/wavepool/newspost.html
+++ b/wavepool/templates/wavepool/newspost.html
@@ -1,6 +1,10 @@
 {% extends 'wavepool/base.html' %}
 {% load static %}
 
+{%  block title %}
+        <title>{{ newspost.title }} | Wavepool | Industry Dive</title>
+{%  endblock %}
+
 {% block page_content %}
 	<div class="row">
 		<div class="col-2"></div>
@@ -19,13 +23,15 @@
 		<div class="col-2"></div>
 	</div>
 	<div class="newspost-detail">
-		<div class="row"><a href=""><button>edit</button></a></div>
+        {% if request.user.is_staff %}
+		<div class="row"><a id="edit-link" href="{% url 'admin:wavepool_newspost_change' newspost.pk %}" target="_blank"><button>edit</button></a></div>
+        {% endif %}
 		<div class="row">
-			<h1>{{ newspost.title }}<span class="pubdate">{{newspost.publish_date}}</span></h1>
+			<h1 id="newspost-title">{{ newspost.title }}</h1><h1><span class="pubdate">{{newspost.publish_date}}</span></h1>
 		</div>
 		<div class="row"><a href="{{newspost.source}}" target="_blank">See the live story at {{newspost.source_divesite_name}}</a></div>
-		<div class="row newspost-body">
-			{{ newspost.body|safe }}
+		<div class="row newspost-body" id="newspost-body">
+			{{ newspost.clean_body|safe }}
 		</div>
 	</div>
 

--- a/wavepool/tests.py
+++ b/wavepool/tests.py
@@ -13,6 +13,7 @@ class TestBase(TestCase):
     fixtures = ['test_fixture', ]
 
     def _clean_text(self, text):
+        text = BeautifulSoup(text, 'html.parser').text
         return text.replace('\n', '').replace('\t', '')
 
     def _random_string(self, length):
@@ -54,7 +55,7 @@ class NewsPostDetail(TestBase):
             rendered_title = page_html.find('h1', {'id': 'newspost-title'}).text
             rendered_body = page_html.find('div', {'id': 'newspost-body'}).text
             self.assertEqual(rendered_title, newspost.title)
-            self.assertEqual(self._clean_text(rendered_body), self._clean_text(newspost.body))
+            self.assertEqual(self._clean_text(rendered_body), self._clean_text(newspost.clean_body))
 
     def test_newspost_body_render(self):
         """ Verify that newsposts rendered at their URL do not display raw HTML to the screen


### PR DESCRIPTION
This PR combines many bug fixes. Normally I would separate this into pull requests that are less all over the place and more logically align but for the purposes of the exercise everything is here. 

### Tasks
1. Add logic for the title tag to be written by the template on story detail pages.
2. Add logic to only display "edit" button for staff members, and link the button to the cms.
3. Add ids to story detail template elements to make the unit tests happy. 
4. Add logic to `source_divesite_name` property on `NewsPost` model to actually work.
5. Guarantee that story content always gets rendered as valid html.

### Solutions
#### Task 1, 2 and 3
Tasks 1, 2 and 3 are all relatively straightforward template changes, and don't really require much discussion.
#### Task 4
Using regex, the method searches for the domain name from the models `source` and matches it from a dictionary. The regex itself maybe a little simple, and can probably be made to be more rigid if need be. For now though, this current regex is adequate. 
#### Task 5
This was a little more involved. We cannot guarantee that the valid html is being stored in the database. As such a `clean_body` property was made that parses the `body` text through `BeautifulSoup` before it gets rendered by the template. This property was then also used to update the unit tests, so that comparing html strings is valid.

### Testing
0. Check that `python manage.py test wavepool.tests.NewsPostDetail` passes with flying colours.
1. Go to any story detail page, such as `http://localhost:8000/news/4/`. Confirm that the title of the story appears in your browsers tab.
2. While **NOT** logged in, go to a story detail page, such as `http://localhost:8000/news/4/`. Confirm that you **do not** see an edit button on the page. Next, login as a staff user and visit the same page. Observe that there is an "edit" button and that clicking on it takes you to the correct page in the CMS to edit the story.
3. Nothing really to manually test here or validate. Just make sure the unit tests pass.
4. On a couple of different news post detail pages, confirm that the text under the publication date, is in the form "See the live story at [Site]". Confirm that the links link to the external sites that match the wording.
5. Confirm that the story at `http://localhost:8000/news/3/` renders okay. 

### Future work
It's a little frustrating that invalid html is in the database to begin with. At the very least, some form validation should be done on the html fields to make sure it is valid. A change in widget would probably help aid this process.