### PR TITLE
Fix bugs outlined in instructions

### DIFF
--- a/wavepool/models.py
+++ b/wavepool/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.urls import reverse
 
 import datetime
+import re
 
 DIVESITE_SOURCE_NAMES = {
     'retaildive': 'Retail Dive',
@@ -31,8 +32,24 @@ class NewsPost(models.Model):
         return self.body[:150]
 
     @property
-    def source_divesite_name(self):
-        return 'Industry Dive'
+    def source_divesite_name(self):      
+        # use regex to match source url against DIVESITE_SOURCE_NAMES
+        # will search up to two domain groups for a match (see illustration) 
+        # https://subdomain.somewebsite.co.uk/other-stuff
+        #         [   #1  ] [   #2    ]
+        
+
+        match_string = r'(?:https?\:\/\/)([a-zA-Z0-9\-]+)\.([a-zA-Z0-9\-]+)'
+        domains = re.findall(match_string, self.source)
+
+        # search through capture groups for a match
+        if domains:
+            for d in domains[0]: 
+                if exists := DIVESITE_SOURCE_NAMES.get(d, False):
+                    return exists
+
+        # default
+        return 'Industry Dive'       
 
     def tags(self):
         return [

--- a/wavepool/templates/wavepool/base.html
+++ b/wavepool/templates/wavepool/base.html
@@ -3,7 +3,7 @@
 	<head>
   		<link href="{% static 'bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
   		<link href="{% static 'app.css' %}" rel="stylesheet">
-  		<title>Wavepool | Industry Dive</title>
+  		<title>{% block page_title %}Wavepool | Industry Dive{% endblock %}</title>
   		<link rel="shortcut icon" type="/image/png" href="{% static 'favicon.ico' %}"/>
   </head>
 	<body>

--- a/wavepool/templates/wavepool/newspost.html
+++ b/wavepool/templates/wavepool/newspost.html
@@ -1,6 +1,8 @@
 {% extends 'wavepool/base.html' %}
 {% load static %}
 
+{% block page_title %}{{page_title}}{% endblock %}
+
 {% block page_content %}
 	<div class="row">
 		<div class="col-2"></div>
@@ -19,12 +21,15 @@
 		<div class="col-2"></div>
 	</div>
 	<div class="newspost-detail">
-		<div class="row"><a href=""><button>edit</button></a></div>
+		{% if request.user.is_authenticated %}
+			<div class="row"><a id="edit-link" href="{{edit_url}}"><button>edit</button></a></div>
+		{% endif %}
+		
 		<div class="row">
-			<h1>{{ newspost.title }}<span class="pubdate">{{newspost.publish_date}}</span></h1>
+			<div><h1 id="newspost-title">{{ newspost.title }}</h1><span class="pubdate">{{newspost.publish_date}}</span></div>
 		</div>
 		<div class="row"><a href="{{newspost.source}}" target="_blank">See the live story at {{newspost.source_divesite_name}}</a></div>
-		<div class="row newspost-body">
+		<div class="row" id="newspost-body">
 			{{ newspost.body|safe }}
 		</div>
 	</div>

--- a/wavepool/views.py
+++ b/wavepool/views.py
@@ -30,8 +30,11 @@ def front_page(request):
 def newspost_detail(request, newspost_id):
     template = loader.get_template('wavepool/newspost.html')
     newspost = NewsPost.objects.get(pk=newspost_id)
+    
     context = {
-        'newspost': newspost
+        'newspost': newspost,
+        'page_title': '%s | Wavepool | Industry Dive' % newspost.title,
+        'edit_url': '/admin/wavepool/newspost/%s/change/' % newspost_id,
     }
 
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
Business Requirements

	• Each news post has a unique URL No changes made for this item.
	• The contents of a news post specified by its URL are displayed using the 'newpost.html' template
	• The news post content should be rendered as formatted HTML on the page
	• Non-logged in users cannot see the "edit" button on the news post page
	• Logged in CMS users can see an "edit" button which opens the CMS change page for the news post
	• The title tag of a news post page should be "[story title] | Wavepool | Industry Dive", where the [story title] is the correct title for the given news post
	• The source link should contain the name of the specific dive site that source is from. There is a map of dive site short names to their display names in the models.py file

Technical context

	• Made changes to the newspost.html and base.html templates to support dynamic titles
	• Added ID tags to the newspost.html news title and body containers
	• Added an edit button to the newspost.html template that displays only for privileged users
	• Updated the newspost model to extract divesite names from news source URLs, then display them on the newspost page. 

Manual testing

	• Login as a privileged user, visit a news post, and verify that an Edit button will take you to the admin portal for that news item. Verify that the button is not visible when not signed in.
	• Verify that different news posts show the article title in the browser title bar, displayed in the format of "Article Title | Wavepool | Industry Dive"
	• From a news post page, verify that the "See the live story at ____" link shows the name of the source website e.g. Restaurant Dive, HR Dive, etc.
	• Verify that a news post page displays the same H1 title and main Body as its Title and Body tags from the CMS/admin portal. 
	• Note!! The wavepool.tests.NewsPostDetail.test_newspost_page_content test does not pass -- need additional information to evaluate this item. 
